### PR TITLE
Load MathJax only if not present yet.

### DIFF
--- a/scripts/JSRootCore.js
+++ b/scripts/JSRootCore.js
@@ -575,8 +575,10 @@
       }
 
       if (kind.indexOf("mathjax;")>=0) {
-         allfiles += "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG," +
-                      JSROOT.source_dir + "scripts/mathjax_config.js;";
+         if (typeof MathJax == 'undefined') {
+            allfiles += "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG," +
+                         JSROOT.source_dir + "scripts/mathjax_config.js;";
+         }
          if (JSROOT.MathJax == 0) JSROOT.MathJax = 1;
       }
 


### PR DESCRIPTION
We added a simple if statement to check whether mathjax is already loaded:

```javascript
if (typeof MathJax == 'undefined') {
    ...
}
```

On our platform, mathjax may already be loaded, so this modification prevents
redundant resource loading.